### PR TITLE
[-] FO : Test if stats is not empty

### DIFF
--- a/followup.php
+++ b/followup.php
@@ -436,10 +436,12 @@ class Followup extends Module
 			GROUP BY DATE_FORMAT(l.date_add, \'%Y-%m-%d\'), l.id_email_type');
 
 		$stats_array = array();
-		foreach ($stats as $stat)
-		{
-			$stats_array[$stat['date_stat']][$stat['id_email_type']]['nb'] = (int)$stat['nb'];
-			$stats_array[$stat['date_stat']][$stat['id_email_type']]['nb_used'] = (int)$stat['nb_used'];
+		if (!empty($stats)) {
+			foreach ($stats as $stat)
+			{
+				$stats_array[$stat['date_stat']][$stat['id_email_type']]['nb'] = (int)$stat['nb'];
+				$stats_array[$stat['date_stat']][$stat['id_email_type']]['nb_used'] = (int)$stat['nb_used'];
+			}
 		}
 
 		foreach ($stats_array as $date_stat => $array)


### PR DESCRIPTION
`$stats` may not be an array, which will lead to an  php warning.

Closes #7 

I did not check if `$stats` is an array because the result of the `executeS` method may be `array|false|null|mysqli_result|PDOStatement|resource` according to [Db class](https://github.com/PrestaShop/PrestaShop/blob/e84f2bb8a566a6240cf901e2c2cfa326946f86f7/classes/db/Db.php#L534) (and because `empty` is a little faster than `is_array`)
Another possibility is to check : `if $stats !==null and $stats !== false`

Sorry for the convention ;)
